### PR TITLE
Ability to configure a proxy for API connections

### DIFF
--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/apiConnector/EcsApiConnectorImpl.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/apiConnector/EcsApiConnectorImpl.kt
@@ -38,11 +38,11 @@ class EcsApiConnectorImpl(awsCredentials: AWSCredentials?, awsRegion: String?) :
             clientConfig.setProxyPort(httpProxyPort)
         }
 
-        if (httpProxyUser.isBlank()){
+        if (!httpProxyUser.isBlank()){
             clientConfig.setProxyUsername(httpProxyUser)
         }
 
-        if (httpProxyPassword.isBlank()){
+        if (!httpProxyPassword.isBlank()){
             clientConfig.setProxyPassword(httpProxyPassword)
         }
 

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/apiConnector/EcsApiConnectorImpl.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/apiConnector/EcsApiConnectorImpl.kt
@@ -38,11 +38,11 @@ class EcsApiConnectorImpl(awsCredentials: AWSCredentials?, awsRegion: String?) :
             clientConfig.setProxyPort(httpProxyPort)
         }
 
-        if (!httpProxyUser.isBlank()){
+        if (!httpProxyUser.isEmpty()){
             clientConfig.setProxyUsername(httpProxyUser)
         }
 
-        if (!httpProxyPassword.isBlank()){
+        if (!httpProxyPassword.isEmpty()){
             clientConfig.setProxyPassword(httpProxyPassword)
         }
 


### PR DESCRIPTION
Hi there!

This project is really awesome, and we have started to trial it in our environment. Our environment requires connections from hosts to be completed through a proxy so I have made this change in order to support environments where outside HTTP connections are required to go through the proxy. I have never programmed in Kotlin before, so please go easy..

I don't see any user documentation, so I wasn't sure where I should add these properties. If you have some, I can add these configuration or can spend some time documenting how to use it. 

I wasn't particular sure how to configure tests either in my environment, but if you want to have some tests around this, if you could point me in the right direction I'm more than happy to add them.

**Changes:**

- Create a shared ClientConfiguration object to be used for AmazonECSClientBuilder and the AmazonCloudWatchClientBuilder.

- Import the TeamCityProperties class to load internal properties from the TeamCity instance.

I have used the following naming standard for creating properties:
`teamcity.ecs.*`

cc\ @iambridgetkate

Thanks,
Sriram