### PR TITLE
Allow passing VPC security groups to build images

### DIFF
--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageData.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageData.kt
@@ -14,6 +14,7 @@ class EcsCloudImageData(private val rawImageData: CloudImageParameters) {
     val agentPoolId: Int? = rawImageData.agentPoolId
     val taskGroup: String? = rawImageData.getParameter(TASK_GROUP_PARAM)
     val subnets: String? = rawImageData.getParameter(SUBNETS_PARAM)
+    val securityGroups: String? = rawImageData.getParameter(SECURITY_GROUPS_PARAM)
     val cluster: String? = rawImageData.getParameter(CLUSTER_PARAM)
     val taskDefinition: String = rawImageData.getParameter(TASK_DEFINITION_PARAM)!!
 

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageImpl.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageImpl.kt
@@ -45,6 +45,12 @@ class EcsCloudImageImpl(private val imageData: EcsCloudImageData,
             return if(rawSubnetsString.isNullOrEmpty()) emptyList() else rawSubnetsString!!.lines()
         }
 
+    private val securityGroups: Collection<String>
+        get() {
+            val rawSecurityGroupsString = imageData.securityGroups?.trim()
+            return if(rawSecurityGroupsString.isNullOrEmpty()) emptyList() else rawSecurityGroupsString!!.lines()
+        }
+
     private val assignPublicIp: Boolean
         get() = imageData.assignPublicIp
 
@@ -131,7 +137,7 @@ class EcsCloudImageImpl(private val imageData: EcsCloudImageData,
                 additionalEnvironment.put(TEAMCITY_ECS_PROVIDED_PREFIX + pair.key, pair.value)
             }
 
-            val tasks = apiConnector.runTask(launchType, taskDefinition, cluster, taskGroup, subnets, assignPublicIp, additionalEnvironment, startedByTeamCity(serverUUID))
+            val tasks = apiConnector.runTask(launchType, taskDefinition, cluster, taskGroup, subnets, securityGroups, assignPublicIp, additionalEnvironment, startedByTeamCity(serverUUID))
 
             newInstance = CachingEcsCloudInstance(EcsCloudInstanceImpl(instanceId, this, tasks[0], apiConnector), cache)
         } catch (ex: Throwable){

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsParameterConstants.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsParameterConstants.kt
@@ -13,6 +13,7 @@ val LAUNCH_TYPE_PARAM = "launchType"
 val TASK_DEFINITION_PARAM = "taskDefinition"
 val TASK_GROUP_PARAM = "taskGroup"
 val SUBNETS_PARAM = "subnets"
+val SECURITY_GROUPS_PARAM = "securityGroups"
 val ASSIGN_PUBLIC_IP_PARAM = "assignPublicIp"
 val CLUSTER_PARAM = "cluster"
 val AGENT_NAME_PREFIX = "agentNamePrefix"
@@ -24,6 +25,7 @@ class EcsParameterConstants{
     val cluster: String = CLUSTER_PARAM
     val taskGroup: String = TASK_GROUP_PARAM
     val subnets: String = SUBNETS_PARAM
+    val securityGroups: String = SECURITY_GROUPS_PARAM
     val assignPublicIp: String = ASSIGN_PUBLIC_IP_PARAM
     val maxInstances: String = IMAGE_INSTANCE_LIMIT_PARAM
     val agentPoolIdField: String = CloudImageParameters.AGENT_POOL_ID_FIELD

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/apiConnector/EcsApiConnector.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/apiConnector/EcsApiConnector.kt
@@ -14,6 +14,7 @@ interface EcsApiConnector {
                 cluster: String?,
                 taskGroup: String?,
                 subnets: Collection<String>,
+                securityGroups: Collection<String>,
                 assignPublicIp: Boolean,
                 additionalEnvironment: Map<String, String>,
                 startedBy: String?): List<EcsTask>

--- a/aws-ecs-server/src/main/resources/buildServerResources/ecsSettings.css
+++ b/aws-ecs-server/src/main/resources/buildServerResources/ecsSettings.css
@@ -20,3 +20,8 @@ textarea .subnetList {
     width: 100%;
     height: 30em;
 }
+
+textarea .securityGroupList {
+    width: 100%;
+    height: 30em;
+}

--- a/aws-ecs-server/src/main/resources/buildServerResources/ecsSettings.js
+++ b/aws-ecs-server/src/main/resources/buildServerResources/ecsSettings.js
@@ -5,7 +5,7 @@ if(!BS.Ecs.ProfileSettingsForm) BS.Ecs.ProfileSettingsForm = OO.extend(BS.Plugin
 
     testConnectionUrl: '',
 
-    _dataKeys: [ 'launchType', 'taskDefinition', 'agentNamePrefix', 'cluster', 'taskGroup', 'subnets', 'assignPublicIp', 'maxInstances', 'cpuReservationLimit', 'agent_pool_id'],
+    _dataKeys: [ 'launchType', 'taskDefinition', 'agentNamePrefix', 'cluster', 'taskGroup', 'subnets', 'securityGroups', 'assignPublicIp', 'maxInstances', 'cpuReservationLimit', 'agent_pool_id'],
 
     templates: {
         imagesTableRow: $j('<tr class="imagesTableRow">\
@@ -63,6 +63,7 @@ if(!BS.Ecs.ProfileSettingsForm) BS.Ecs.ProfileSettingsForm = OO.extend(BS.Plugin
         this.$agentNamePrefix = $j('#agentNamePrefix');
         this.$taskGroup = $j('#taskGroup');
         this.$subnets = $j('#subnets');
+        this.$securityGroups = $j('#securityGroups');
         this.$assignPublicIp = $j('#assignPublicIp');
         this.$cluster = $j('#cluster');
         this.$maxInstances = $j('#maxInstances');
@@ -163,6 +164,12 @@ if(!BS.Ecs.ProfileSettingsForm) BS.Ecs.ProfileSettingsForm = OO.extend(BS.Plugin
         this.$subnets.on('change', function (e, value) {
             if(value !== undefined) this.$subnets.val(value);
             this._image['subnets'] = this.$subnets.val();
+            this.validateOptions(e.target.getAttribute('data-id'));
+        }.bind(this));
+
+        this.$securityGroups.on('change', function (e, value) {
+            if(value !== undefined) this.$securityGroups.val(value);
+            this._image['securityGroups'] = this.$securityGroups.val();
             this.validateOptions(e.target.getAttribute('data-id'));
         }.bind(this));
 
@@ -292,6 +299,7 @@ if(!BS.Ecs.ProfileSettingsForm) BS.Ecs.ProfileSettingsForm = OO.extend(BS.Plugin
         this.$agentNamePrefix.trigger('change', image['agentNamePrefix'] || '');
         this.$taskGroup.trigger('change', image['taskGroup'] || '');
         this.$subnets.trigger('change', image['subnets'] || '');
+        this.$securityGroups.trigger('change', image['securityGroups'] || '');
         this.$assignPublicIp.prop('checked', image['assignPublicIp'] === 'true' ? image['assignPublicIp'] : '');
         this.selectCluster(image['cluster'] || '');
         this.$maxInstances.trigger('change', image['maxInstances'] || '');
@@ -309,6 +317,7 @@ if(!BS.Ecs.ProfileSettingsForm) BS.Ecs.ProfileSettingsForm = OO.extend(BS.Plugin
         this.$agentNamePrefix.trigger('change', '');
         this.$taskGroup.trigger('change', '');
         this.$subnets.trigger('change', '');
+        this.$securityGroups.trigger('change', '');
         this.$assignPublicIp.prop('checked', '');
         this.selectCluster('');
         this.$maxInstances.trigger('change', '');

--- a/aws-ecs-server/src/main/resources/buildServerResources/editProfile.jsp
+++ b/aws-ecs-server/src/main/resources/buildServerResources/editProfile.jsp
@@ -142,6 +142,14 @@
             </td>
         </tr>
         <tr class="advancedSetting">
+            <th>Security Groups:</th>
+            <td>
+                <textarea id="${cons.securityGroups}" wrap="off" class="securityGroupList" data-id="${cons.securityGroups}" data-err-id="${cons.securityGroups}"></textarea>
+                <div class="smallNoteAttention">Optional new line delimited list of security group IDs in cluster VPC that TeamCity should apply to the task if run with the networking mode awsvpc. If left blank, the default VPC security group will be used.</div>
+                <span class="error option-error option-error_${cons.securityGroups}"></span>
+            </td>
+        </tr>
+        <tr class="advancedSetting">
             <th>Assign public IP:</th>
             <td>
                 <input type="checkbox" id="${cons.assignPublicIp}" wrap="off" data-id="${cons.assignPublicIp}" data-err-id="${cons.assignPublicIp}"/>


### PR DESCRIPTION
Hey everyone,

First of all, my team has been evaluating TeamCity with ECS build agents and really liking it so far. Because we're a small team, we'd like to run our build agents in Fargate so we don't have to keep an ECS cluster running all the time. Due to the way our larger organization sets up our AWS environment, the default VPC security group has no access to anything - we have to define custom security groups for any purpose.

Since the AWS runTask API call supports passing security groups as well as subnets for tasks run with the awsvpc networking mode, I've made a change to the agent image configuration modal to add a security groups field, modeled after the subnets field. The groups are passed to the runTask call, in the securityGroups parameter as defined [here.](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_AwsVpcConfiguration.html#ECS-Type-AwsVpcConfiguration-securityGroups)

There seemed to be no relevant tests, but if I missed them or anything else, let me know and I'll take care of it. Also, if there is documentation I should update, let me know.

This is my first time writing Kotlin code, I'm more used to Java and Scala as my JVM languages. I do appreciate constructive feedback if I can make my code better.

Thanks for your time,

Dillon
