### PR TITLE
Multiple fixes

### DIFF
--- a/aws-ecs-server/build.gradle
+++ b/aws-ecs-server/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.2"
 
 
-    compile 'jetbrains.buildServer.util:amazon-util:39'
+    compile 'jetbrains.buildServer.util:amazon-util:32'
     provided "org.jetbrains.teamcity:cloud-interface:$teamcityVersion"
     provided "org.jetbrains.teamcity:cloud-shared:$teamcityVersion"
     provided "org.jetbrains.teamcity:cloud-server-api:$teamcityVersion"

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudClient.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudClient.kt
@@ -5,7 +5,6 @@ import com.intellij.openapi.diagnostic.Logger
 import jetbrains.buildServer.agent.Constants
 import jetbrains.buildServer.clouds.*
 import jetbrains.buildServer.serverSide.AgentDescription
-import java.io.File
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
@@ -13,7 +12,6 @@ class EcsCloudClient(images: List<EcsCloudImage>,
                      private val updater: EcsInstancesUpdater,
                      private val ecsClientParams: EcsCloudClientParameters,
                      private val serverUuid: String,
-                     private val idxStorage: File,
                      private val cloudProfileId: String) : CloudClientEx {
     private val LOG = Logger.getInstance(EcsCloudClient::class.java.getName())
 

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudClient.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudClient.kt
@@ -38,17 +38,17 @@ class EcsCloudClient(images: List<EcsCloudImage>,
     }
 
     override fun canStartNewInstance(image: CloudImage): Boolean {
-        val kubeCloudImage = image as EcsCloudImage
-        val kubeCloudImageId = kubeCloudImage.getId()
-        if (!myImageIdToImageMap.containsKey(kubeCloudImageId)) {
-            LOG.debug("Can't start instance of unknown cloud image with id " + kubeCloudImageId)
+        val ecsCloudImage = image as EcsCloudImage
+        val ecsCloudImageId = ecsCloudImage.getId()
+        if (!myImageIdToImageMap.containsKey(ecsCloudImageId)) {
+            LOG.debug("Can't start instance of unknown cloud image with id " + ecsCloudImageId)
             return false
         }
 
-        if (ecsClientParams.instanceLimit in 1..images.sumBy { image.runningInstanceCount })
+        if (ecsClientParams.instanceLimit in 1..images.sumBy { (it as EcsCloudImage).runningInstanceCount })
             return false
 
-        return kubeCloudImage.canStartNewInstance()
+        return ecsCloudImage.canStartNewInstance()
     }
 
     override fun startNewInstance(image: CloudImage, tag: CloudInstanceUserData): CloudInstance {

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudClientFactory.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudClientFactory.kt
@@ -7,7 +7,6 @@ import jetbrains.buildServer.clouds.ecs.web.EDIT_ECS_HTML
 import jetbrains.buildServer.serverSide.*
 import jetbrains.buildServer.util.amazon.AWSCommonParams
 import jetbrains.buildServer.web.openapi.PluginDescriptor
-import java.io.File
 import java.util.*
 
 fun startedByTeamCity(serverUUID: String?): String {
@@ -28,13 +27,9 @@ class EcsCloudClientFactory(cloudRegister: CloudRegistrar,
                             private val cache: EcsDataCache,
                             private val instanceUpdater: EcsInstancesUpdater) : CloudClientFactory {
     private val editUrl = pluginDescriptor.getPluginResourcesPath(EDIT_ECS_HTML)
-    private val idxStorage = File(serverPaths.pluginDataDirectory, "ecsCloudIdx")
 
     init {
         cloudRegister.registerCloudFactory(this)
-        if (!idxStorage.exists()){
-            idxStorage.mkdirs()
-        }
     }
 
     override fun getCloudCode(): String {
@@ -62,11 +57,11 @@ class EcsCloudClientFactory(cloudRegister: CloudRegistrar,
         val apiConnector = EcsApiConnectorImpl(ecsParams.awsCredentials, ecsParams.region)
         val serverUUID = serverSettings.serverUUID!!
         val images = ecsParams.imagesData.map{
-            val image = it.toImage(apiConnector, cache, serverUUID, idxStorage, state.profileId)
+            val image = it.toImage(apiConnector, cache, serverUUID, state.profileId)
             image.populateInstances()
             image
         }
-        return EcsCloudClient(images, instanceUpdater, ecsParams, serverUUID, idxStorage, state.profileId)
+        return EcsCloudClient(images, instanceUpdater, ecsParams, serverUUID, state.profileId)
     }
 
     override fun getInitialParameterValues(): MutableMap<String, String> {

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageData.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageData.kt
@@ -4,14 +4,12 @@ import com.amazonaws.services.ecs.model.LaunchType
 import jetbrains.buildServer.clouds.CloudImageParameters
 import jetbrains.buildServer.clouds.ecs.apiConnector.EcsApiConnector
 import jetbrains.buildServer.util.StringUtil
-import java.io.File
 
 fun EcsCloudImageData.toImage(apiConnector: EcsApiConnector,
                               cache: EcsDataCache,
                               serverUUID: String,
-                              idxStorage: File,
                               profileId: String): EcsCloudImage
-        = EcsCloudImageImpl(this, apiConnector, cache, serverUUID, idxStorage, profileId)
+        = EcsCloudImageImpl(this, apiConnector, cache, serverUUID, profileId)
 
 class EcsCloudImageData(private val rawImageData: CloudImageParameters) {
     val id: String = rawImageData.id!!

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageData.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageData.kt
@@ -32,7 +32,7 @@ class EcsCloudImageData(private val rawImageData: CloudImageParameters) {
             return if (StringUtil.isEmpty(parameter)) -1 else Integer.valueOf(parameter)
         }
 
-    val cpuReservalionLimit: Int
+    val cpuReservationLimit: Int
         get() {
             val parameter = rawImageData.getParameter(CPU_RESERVATION_LIMIT_PARAM)
             return if (StringUtil.isEmpty(parameter)) -1 else Integer.valueOf(parameter)

--- a/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageImpl.kt
+++ b/aws-ecs-server/src/main/kotlin/jetbrains/buildServer/clouds/ecs/EcsCloudImageImpl.kt
@@ -35,7 +35,7 @@ class EcsCloudImageImpl(private val imageData: EcsCloudImageData,
             return false
         if(instanceLimit in 1..runningInstanceCount) return false
         val monitoringPeriod = TeamCityProperties.getInteger(ECS_METRICS_MONITORING_PERIOD, 1)
-        return cpuReservalionLimit <= 0 || apiConnector.getMaxCPUReservation(cluster, monitoringPeriod) < cpuReservalionLimit
+        return cpuReservationLimit <= 0 || apiConnector.getMaxCPUReservation(cluster, monitoringPeriod) < cpuReservationLimit
     }
 
 
@@ -45,8 +45,8 @@ class EcsCloudImageImpl(private val imageData: EcsCloudImageData,
     private val instanceLimit: Int
         get() = imageData.instanceLimit
 
-    private val cpuReservalionLimit: Int
-        get() = imageData.cpuReservalionLimit
+    private val cpuReservationLimit: Int
+        get() = imageData.cpuReservationLimit
 
     private val cluster: String?
         get() = imageData.cluster

--- a/aws-ecs-server/src/main/resources/buildServerResources/editProfile.jsp
+++ b/aws-ecs-server/src/main/resources/buildServerResources/editProfile.jsp
@@ -26,10 +26,7 @@
 
 <table class="runnerFormTable">
 
-<jsp:include page="editAWSCommonParams.jsp">
-    <jsp:param name="requireRegion" value="${true}"/>
-    <jsp:param name="requireEnvironment" value="${false}"/>
-</jsp:include>
+<jsp:include page="editAWSCommonParams.jsp" />
 
     <tr>
         <th class="noBorder"></th>


### PR DESCRIPTION
This PR fixes several issues in the ECS Cloud plugin

1.) canStartNewInstance is broken

The code incorrectly sums `<number of images in profile>` * `<number of running instances for image being queried>` to calculate the currently running count. This means that if I have a profile with 10 images, and an image has one running build, the running count will be 10 instead of the correct count of 1

2.) The upgrade to aws-util:39 broke the UI such that using the Default Credential Provider Chain cannot be selected, I've reverted it, but likely aws-util should be fixed instead (it does not appear to be fixed as of the latest build 45)

3.) The index based agent name setting was problematic: If the profile was edited and saved, it could leak polling tasks, and cause ID conflicts. In addition, the code never wrote the updated idx, so every server restart would reset the index to 1. I think it's much simpler to just use a UUID prefixed with the proper task definition name to sidestep all of these issues and guarantee agent name uniqueness. As a side effect of this change, I moved the error instances cleanup code to the populateInstances method so there's no risk of leaving dangling polling jobs scheduled in init.

4.) Multiple timing/synchronization bugs in ECSCloudImageImpl

A few problems here: the ECS API is eventually consistent, so it's possible that a describeTasks won't show a newly created task for some time. This can lead to agents disappearing and reappearing, or not appearing for some time in the myIdToInstanceMap. I added a set of pending tasks that is cleared after 5 minutes to ensure this does not happen. Also, in populateInstances, the call to clear leaves a race window where findInstanceById could return null, even for an instance that is known, since synchronization was only on myIdToInstanceMap, but myIdToInstanceMap.get (as used in findInstanceById) is not a synchronized method. I replaced this with code that instead builds a set of instance ids that should exist in the map at the current time and then calls retainAll on the map's keys so there's never a time when the map is empty.

The result of these timing bugs was that periodically agents started by the cloud plugin would show as unregistered, and not be automatically terminated. This left lots of garbage disconnected agents in place, and required manual stopping of the tasks.


